### PR TITLE
Fixes from `actions/setup-python` PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ steps:
 - run: python my_script.py
 ```
 
+**Free threaded Python**
+```yaml
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-python@v5
+  with:
+    python-version: '3.13t'
+- run: python my_script.py
+```
+
 The `python-version` input is optional. If not supplied, the action will try to resolve the version from the default `.python-version` file. If the `.python-version` file doesn't exist Python or PyPy version from the PATH will be used. The default version of Python or PyPy in PATH varies between runners and can be changed unexpectedly so we recommend always setting Python version explicitly using the `python-version` or `python-version-file` inputs.
 
 The action will first check the local [tool cache](docs/advanced-usage.md#hosted-tool-cache) for a [semver](https://github.com/npm/node-semver#versions) match. If unable to find a specific version in the tool cache, the action will attempt to download a version of Python from [GitHub Releases](https://github.com/actions/python-versions/releases) and for PyPy from the official [PyPy's dist](https://downloads.python.org/pypy/).

--- a/__tests__/find-python.test.ts
+++ b/__tests__/find-python.test.ts
@@ -1,0 +1,18 @@
+import {desugarVersion} from '../src/find-python';
+
+describe('desugarVersion', () => {
+  it.each([
+    ['3.13', ['3.13', '']],
+    ['3.13t', ['3.13', '-freethreaded']],
+    ['3.13.1', ['3.13.1', '']],
+    ['3.13.1t', ['3.13.1', '-freethreaded']],
+    ['3.14-dev', ['~3.14.0-0', '']],
+    ['3.14t-dev', ['~3.14.0-0', '-freethreaded']],
+    ['3.14.0a4', ['3.14.0a4', '']],
+    ['3.14.0ta4', ['3.14.0a4', '-freethreaded']],
+    ['3.14.0rc1', ['3.14.0rc1', '']],
+    ['3.14.0trc1', ['3.14.0rc1', '-freethreaded']]
+  ])('%s -> %s', (input, expected) => {
+    expect(desugarVersion(input)).toEqual(expected);
+  });
+});

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -91006,7 +91006,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.pythonVersionToSemantic = exports.useCpythonVersion = void 0;
+exports.pythonVersionToSemantic = exports.desugarVersion = exports.useCpythonVersion = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
 const utils_1 = __nccwpck_require__(1314);
@@ -91038,9 +91038,8 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
     return __awaiter(this, void 0, void 0, function* () {
         var _a;
         let manifest = null;
-        const [desugaredVersionSpec, freethreaded] = desugarFreeThreadedVersion(version);
-        const desugaredVersionSpec2 = desugarDevVersion(desugaredVersionSpec);
-        let semanticVersionSpec = pythonVersionToSemantic(desugaredVersionSpec2, allowPreReleases);
+        const [desugaredVersionSpec, freethreaded] = desugarVersion(version);
+        let semanticVersionSpec = pythonVersionToSemantic(desugaredVersionSpec, allowPreReleases);
         core.debug(`Semantic version spec of ${version} is ${semanticVersionSpec}`);
         if (freethreaded) {
             // Free threaded versions use an architecture suffix like `x64-freethreaded`
@@ -91121,14 +91120,21 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
     });
 }
 exports.useCpythonVersion = useCpythonVersion;
-/* Identify freethreaded versions like, 3.13t, 3.13t-dev, 3.14.0a1t. Returns
- * the version without the `t` and the architectures suffix, if freethreaded */
+/* Desugar free threaded and dev versions */
+function desugarVersion(versionSpec) {
+    const [desugaredVersionSpec, freethreaded] = desugarFreeThreadedVersion(versionSpec);
+    const desugaredVersionSpec2 = desugarDevVersion(desugaredVersionSpec);
+    return [desugaredVersionSpec2, freethreaded];
+}
+exports.desugarVersion = desugarVersion;
+/* Identify freethreaded versions like, 3.13t, 3.13.1t, 3.13t-dev, 3.14.0a1t.
+ * Returns the version without the `t` and the architectures suffix, if freethreaded */
 function desugarFreeThreadedVersion(versionSpec) {
     const prereleaseVersion = /(\d+\.\d+\.\d+)(t)((?:a|b|rc)\d*)/g;
     if (prereleaseVersion.test(versionSpec)) {
         return [versionSpec.replace(prereleaseVersion, '$1$3'), '-freethreaded'];
     }
-    const majorMinor = /^(\d+\.\d+)(t)$/;
+    const majorMinor = /^(\d+\.\d+(\.\d+)?)(t)$/;
     if (majorMinor.test(versionSpec)) {
         return [versionSpec.replace(majorMinor, '$1'), '-freethreaded'];
     }

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -77,6 +77,20 @@ steps:
 - run: python my_script.py
 ```
 
+Use the **t** suffix to select the [free threading](https://docs.python.org/3/howto/free-threading-python.html) version of Python.
+Free threaded Python is only available starting with the 3.13 release.
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-python@v5
+  with:
+    python-version: '3.13t'
+- run: python my_script.py
+```
+
+Pre-release free threading versions should be specified like `3.14.0ta3` or `3.14t-dev`.
+
 You can also use several types of ranges that are specified in [semver](https://github.com/npm/node-semver#ranges), for instance:
 
 - **[ranges](https://github.com/npm/node-semver#ranges)** to download and set up the latest available version of Python satisfying a range:

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -38,11 +38,9 @@ export async function useCpythonVersion(
   allowPreReleases: boolean
 ): Promise<InstalledVersion> {
   let manifest: tc.IToolRelease[] | null = null;
-  const [desugaredVersionSpec, freethreaded] =
-    desugarFreeThreadedVersion(version);
-  const desugaredVersionSpec2 = desugarDevVersion(desugaredVersionSpec);
+  const [desugaredVersionSpec, freethreaded] = desugarVersion(version);
   let semanticVersionSpec = pythonVersionToSemantic(
-    desugaredVersionSpec2,
+    desugaredVersionSpec,
     allowPreReleases
   );
   core.debug(`Semantic version spec of ${version} is ${semanticVersionSpec}`);
@@ -167,14 +165,22 @@ export async function useCpythonVersion(
   return {impl: 'CPython', version: installed};
 }
 
-/* Identify freethreaded versions like, 3.13t, 3.13t-dev, 3.14.0a1t. Returns
- * the version without the `t` and the architectures suffix, if freethreaded */
+/* Desugar free threaded and dev versions */
+export function desugarVersion(versionSpec: string) {
+  const [desugaredVersionSpec, freethreaded] =
+    desugarFreeThreadedVersion(versionSpec);
+  const desugaredVersionSpec2 = desugarDevVersion(desugaredVersionSpec);
+  return [desugaredVersionSpec2, freethreaded];
+}
+
+/* Identify freethreaded versions like, 3.13t, 3.13.1t, 3.13t-dev, 3.14.0a1t.
+ * Returns the version without the `t` and the architectures suffix, if freethreaded */
 function desugarFreeThreadedVersion(versionSpec: string) {
   const prereleaseVersion = /(\d+\.\d+\.\d+)(t)((?:a|b|rc)\d*)/g;
   if (prereleaseVersion.test(versionSpec)) {
     return [versionSpec.replace(prereleaseVersion, '$1$3'), '-freethreaded'];
   }
-  const majorMinor = /^(\d+\.\d+)(t)$/;
+  const majorMinor = /^(\d+\.\d+(\.\d+)?)(t)$/;
   if (majorMinor.test(versionSpec)) {
     return [versionSpec.replace(majorMinor, '$1'), '-freethreaded'];
   }


### PR DESCRIPTION
* Update documentation
* Fix handling of versions like `3.13.1t` that contain both the "patch" version and the "t" free-threading specifier.
* Add tests for version parsing

Hopefully this will land upstream soon, but I'm also making this PR here because:

1) It runs the CI and makes it easier to test end-to-end
2) Seems like a useful bugfix in the meantime